### PR TITLE
Create release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,8 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-game:
+    runs-on: ubuntu-latest
+    steps:
+      - 


### PR DESCRIPTION
Ideally would be great if the build could happen in GitHub action, need to create a Docker image (work in progress) that could be called upon to do the grunt work.