### PR TITLE
Yorp - State machine

### DIFF
--- a/player/StateMachine.cs
+++ b/player/StateMachine.cs
@@ -52,6 +52,13 @@ public partial class StateMachine : Node
 			((IcedState)states[KeenStates.Iced]).HitByLeftIceChunk = leftIceBlock;
 			forceState = KeenStates.Iced;
 		};
+		signalManager.KeenHitYorpEye += () => 
+		{
+			if (IsPogoing())
+			{
+				forceState = KeenStates.Air;
+			}
+		};
 	}
 
     public void PhysicsProcess(double delta, float lastMovementX)

--- a/scenes/creatures/Yorp/DazedState.cs
+++ b/scenes/creatures/Yorp/DazedState.cs
@@ -1,0 +1,35 @@
+using Godot;
+
+namespace CommanderKeen.Scenes.Creatures.Yorp;
+public partial class DazedState : YorpBaseState
+{
+	public override YorpStateMachine.YorpStates StateType => YorpStateMachine.YorpStates.Dazed;
+	
+	private Timer timer;
+
+	public override void _Ready()
+	{
+		timer = GetNode<Timer>("KnockedOutTimer");
+	}
+
+	private void OnTimerTimeout()
+    {
+        this.NextState = YorpStateMachine.YorpStates.Thinking;
+    }
+
+	public override void StateInput(InputEvent inputEvent)
+	{
+	}
+
+    public override void PhysicsProcess(double delta, float lastMovementX)
+	{
+		Character.Velocity = new Vector2 (0, Character.Velocity.Y + gravity * (float)delta);
+	}
+
+	public override void Enter()
+	{
+		playback.Travel("Dazed");
+		timer.Start();
+	}
+
+}

--- a/scenes/creatures/Yorp/DazedState.cs.uid
+++ b/scenes/creatures/Yorp/DazedState.cs.uid
@@ -1,0 +1,1 @@
+uid://dbufi5gll8xrb

--- a/scenes/creatures/Yorp/DeathState.cs
+++ b/scenes/creatures/Yorp/DeathState.cs
@@ -1,0 +1,24 @@
+using Godot;
+
+namespace CommanderKeen.Scenes.Creatures.Yorp;
+public partial class DeathState : YorpBaseState
+{
+	public override YorpStateMachine.YorpStates StateType => YorpStateMachine.YorpStates.Dead;
+
+	public override bool CanMove => false;
+
+	public override void StateInput(InputEvent inputEvent)
+	{
+	}
+
+    public override void PhysicsProcess(double delta, float lastMovementX)
+	{
+		Character.Velocity = new Vector2 (0, Character.Velocity.Y + gravity * (float)delta);
+	}
+
+	public override void Enter()
+	{
+		playback.Travel("Die");
+	}
+
+}

--- a/scenes/creatures/Yorp/DeathState.cs.uid
+++ b/scenes/creatures/Yorp/DeathState.cs.uid
@@ -1,0 +1,1 @@
+uid://k8j8d4bmqfpg

--- a/scenes/creatures/Yorp/ThinkingState.cs
+++ b/scenes/creatures/Yorp/ThinkingState.cs
@@ -19,6 +19,7 @@ public partial class ThinkingState : YorpBaseState
 
 	public override void PhysicsProcess(double delta, float lastMovementX)
 	{
+		Character.Velocity = new Vector2 (0, Character.Velocity.Y + gravity * (float)delta);
 	}
 
 	public void ThinkingFinished()

--- a/scenes/creatures/Yorp/ThinkingState.cs
+++ b/scenes/creatures/Yorp/ThinkingState.cs
@@ -1,0 +1,45 @@
+using System;
+using Godot;
+
+namespace CommanderKeen.Scenes.Creatures.Yorp;
+public partial class ThinkingState : YorpBaseState
+{
+	public override YorpStateMachine.YorpStates StateType => YorpStateMachine.YorpStates.Thinking;
+	private Random random = new Random();
+	private int thinkAmount;
+	private int direction = 0;
+	
+	public override void _Ready()
+	{
+	}
+
+	public override void StateInput(InputEvent inputEvent)
+	{
+	}
+
+	public override void PhysicsProcess(double delta, float lastMovementX)
+	{
+	}
+
+	public void ThinkingFinished()
+	{
+		thinkAmount--;
+		if (thinkAmount <= 0)
+		{
+			this.NextState = YorpStateMachine.YorpStates.Walk;
+		}
+		
+		direction *=-1;
+		AnimationTree.Set("parameters/Look/blend_position", direction);
+    }
+
+	public override void Enter()
+	{
+		thinkAmount = random.Next(1, 5);
+		direction = random.Next(0, 2) == 0 ? -1 : 1;
+		
+		playback.Travel("Look");
+		AnimationTree.Set("parameters/Look/blend_position", direction);
+		Character.Velocity = Vector2.Zero;
+	}
+}

--- a/scenes/creatures/Yorp/ThinkingState.cs
+++ b/scenes/creatures/Yorp/ThinkingState.cs
@@ -26,6 +26,7 @@ public partial class ThinkingState : YorpBaseState
 		thinkAmount--;
 		if (thinkAmount <= 0)
 		{
+			AnimationTree.Set("parameters/Look/blend_position", 0);
 			this.NextState = YorpStateMachine.YorpStates.Walk;
 		}
 		
@@ -35,7 +36,7 @@ public partial class ThinkingState : YorpBaseState
 
 	public override void Enter()
 	{
-		thinkAmount = random.Next(1, 5);
+		thinkAmount = random.Next(3, 5);
 		direction = random.Next(0, 2) == 0 ? -1 : 1;
 		
 		playback.Travel("Look");

--- a/scenes/creatures/Yorp/ThinkingState.cs.uid
+++ b/scenes/creatures/Yorp/ThinkingState.cs.uid
@@ -1,0 +1,1 @@
+uid://de135f4jgh44g

--- a/scenes/creatures/Yorp/WalkState.cs
+++ b/scenes/creatures/Yorp/WalkState.cs
@@ -1,0 +1,73 @@
+using System;
+using Godot;
+
+namespace CommanderKeen.Scenes.Creatures.Yorp;
+public partial class WalkState : YorpBaseState
+{
+	[Export]
+	public float MaxJumpVelocity = -200.0f;
+	private Random random = new Random();
+
+    public override YorpStateMachine.YorpStates StateType => YorpStateMachine.YorpStates.Walk;
+
+	private Timer walkTimer;
+	private Timer jumpTimer;
+
+	public override void _Ready()
+	{
+		walkTimer = GetNode<Timer>("WalkTimer");
+		jumpTimer = GetNode<Timer>("JumpTimer");
+	}
+
+    private void OnTimerTimeout()
+    {
+        this.NextState = YorpStateMachine.YorpStates.Thinking;
+		walkTimer.Stop();
+		jumpTimer.Stop();
+    }
+
+    public override void StateInput(InputEvent inputEvent)
+	{
+	}
+
+    public override void PhysicsProcess(double delta, float lastMovementX)
+	{
+		if (Character.IsOnFloor() && Character.IsOnWall())
+		{
+			lastMovementX = -lastMovementX;
+		}
+		else
+		{
+			lastMovementX = Character.Velocity.X > 0 ? Vector2.Right.X : Vector2.Left.X;
+		}
+
+		AnimationTree.Set("parameters/Walk/blend_position", lastMovementX);
+		Character.Velocity = new Vector2(lastMovementX * Speed, Character.Velocity.Y + gravity * (float)delta);
+	}
+
+	public override void Enter()
+	{
+		playback.Travel("Walk");
+
+		// Walk time is around 1-5 seconds
+		walkTimer.WaitTime = random.Next(1, 5);
+		walkTimer.Start();
+
+		jumpTimer.WaitTime = random.Next(1, 5);
+		jumpTimer.Start();
+
+		// Look up Keen direction
+		var keen = GetTree().GetNodesInGroup("Player")[0] as Keen;
+		var direction = keen.GlobalPosition.X < Character.GlobalPosition.X ? Vector2.Left.X : Vector2.Right.X;
+		AnimationTree.Set("parameters/Walk/blend_position", direction);
+		Character.Velocity = Character.Velocity with { X = direction };
+	}
+
+	private void Jump()
+	{
+		if (Character.IsOnFloor())
+		{
+			Character.Velocity = new Vector2(Character.Velocity.X, random.Next((int)MaxJumpVelocity, 0));
+		}
+	}
+}

--- a/scenes/creatures/Yorp/WalkState.cs
+++ b/scenes/creatures/Yorp/WalkState.cs
@@ -63,11 +63,17 @@ public partial class WalkState : YorpBaseState
 		Character.Velocity = Character.Velocity with { X = direction };
 	}
 
+	public override void ExitState()
+	{
+		walkTimer.Stop();
+		jumpTimer.Stop();
+	}
+
 	private void Jump()
 	{
 		if (Character.IsOnFloor())
 		{
-			Character.Velocity = new Vector2(Character.Velocity.X, random.Next((int)MaxJumpVelocity, 0));
+			Character.Velocity = Character.Velocity with { Y = random.Next((int)MaxJumpVelocity, 0) };
 		}
 	}
 }

--- a/scenes/creatures/Yorp/WalkState.cs
+++ b/scenes/creatures/Yorp/WalkState.cs
@@ -12,6 +12,7 @@ public partial class WalkState : YorpBaseState
 
 	private Timer walkTimer;
 	private Timer jumpTimer;
+	private bool jump = false;
 
 	public override void _Ready()
 	{
@@ -21,7 +22,6 @@ public partial class WalkState : YorpBaseState
 
     private void OnTimerTimeout()
     {
-        this.NextState = YorpStateMachine.YorpStates.Thinking;
 		walkTimer.Stop();
 		jumpTimer.Stop();
     }
@@ -32,6 +32,17 @@ public partial class WalkState : YorpBaseState
 
     public override void PhysicsProcess(double delta, float lastMovementX)
 	{
+		if (Character.IsOnFloor() && jump)
+		{
+			jump = false;
+			Character.Velocity = Character.Velocity with { Y = random.Next((int)MaxJumpVelocity, 0) };
+		}
+		
+		if (walkTimer.IsStopped() && Character.IsOnFloor())
+		{
+			this.NextState = YorpStateMachine.YorpStates.Thinking;
+		}
+
 		if (Character.IsOnFloor() && Character.IsOnWall())
 		{
 			lastMovementX = -lastMovementX;
@@ -71,9 +82,6 @@ public partial class WalkState : YorpBaseState
 
 	private void Jump()
 	{
-		if (Character.IsOnFloor())
-		{
-			Character.Velocity = Character.Velocity with { Y = random.Next((int)MaxJumpVelocity, 0) };
-		}
+		jump = true;
 	}
 }

--- a/scenes/creatures/Yorp/WalkState.cs.uid
+++ b/scenes/creatures/Yorp/WalkState.cs.uid
@@ -1,0 +1,1 @@
+uid://d2ykcrtkskta8

--- a/scenes/creatures/Yorp/Yorp.cs
+++ b/scenes/creatures/Yorp/Yorp.cs
@@ -34,11 +34,8 @@ public partial class Yorp : CharacterBody2D, ITakeDamage
 
 	private void KnockedOut(Node body)
 	{
-		if (body is Keen)
-		{
-			signalManager.EmitSignal(nameof(SignalManager.KeenHitYorpEye));
-			stateMachine.KnockedOut();
-		}		
+		signalManager.EmitSignal(nameof(SignalManager.KeenHitYorpEye));
+		stateMachine.KnockedOut();
 	}
 
     public void TakeDamage()

--- a/scenes/creatures/Yorp/Yorp.cs
+++ b/scenes/creatures/Yorp/Yorp.cs
@@ -34,7 +34,11 @@ public partial class Yorp : CharacterBody2D, ITakeDamage
 
 	private void KnockedOut(Node body)
 	{
-		stateMachine.KnockedOut();
+		if (body is Keen)
+		{
+			signalManager.EmitSignal(nameof(SignalManager.KeenHitYorpEye));
+			stateMachine.KnockedOut();
+		}		
 	}
 
     public void TakeDamage()

--- a/scenes/creatures/Yorp/Yorp.cs
+++ b/scenes/creatures/Yorp/Yorp.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace CommanderKeen.Scenes.Creatures.Yorp;
 public partial class Yorp : CharacterBody2D, ITakeDamage
 {
-	public const float ShovePower = 2.0f;
+	public const float ShovePower = 3.0f;
 
 	private int Health = 1;
 
@@ -29,7 +29,20 @@ public partial class Yorp : CharacterBody2D, ITakeDamage
 		}
 		
 		stateMachine.PhysicsProcess(delta, lastMovementX, isActivated);
-		MoveAndSlide();
+		
+		if (MoveAndSlide())
+		{
+			for (int i = 0; i < GetSlideCollisionCount(); i++)
+			{
+				var collision = GetSlideCollision(i);
+
+				if (collision.GetCollider() is Keen keen)
+				{
+					Debug.WriteLine($"Collided with Player - Yorp last x: {lastMovementX}");
+					keen.Shove(ShovePower * lastMovementX, (float)delta);
+				}
+			}
+		}
 	}
 
 	private void KnockedOut(Node body)

--- a/scenes/creatures/Yorp/Yorp.cs
+++ b/scenes/creatures/Yorp/Yorp.cs
@@ -47,8 +47,11 @@ public partial class Yorp : CharacterBody2D, ITakeDamage
 
 	private void KnockedOut(Node body)
 	{
-		signalManager.EmitSignal(nameof(SignalManager.KeenHitYorpEye));
-		stateMachine.KnockedOut();
+		if (body is Keen keen && keen.Velocity.Y > 0)
+		{
+			signalManager.EmitSignal(nameof(SignalManager.KeenHitYorpEye));
+			stateMachine.KnockedOut();
+		}
 	}
 
     public void TakeDamage()

--- a/scenes/creatures/Yorp/Yorp.cs
+++ b/scenes/creatures/Yorp/Yorp.cs
@@ -2,176 +2,58 @@ using Godot;
 using System;
 using System.Diagnostics;
 
+namespace CommanderKeen.Scenes.Creatures.Yorp;
 public partial class Yorp : CharacterBody2D, ITakeDamage
 {
-	[Export]
-	public float Speed = 180.0f;
-	
-	[Export]
-	public float MaxJumpVelocity = -200.0f;
-
 	public const float ShovePower = 2.0f;
 
 	private int Health = 1;
 
-	public enum YorpState{
-		Idle,
-		WalkingLeft,
-		WalkingRight,
-		Thinking,
-		Jumping,
-		KnockedOut,
-		Dying
-	}
+	private YorpStateMachine stateMachine = new YorpStateMachine();
+	private SignalManager signalManager;
 
-	[Export]
-	private YorpState state = YorpState.Idle;
-	private YorpState previousState = YorpState.Idle;
-
-	private AnimationPlayer animationPlayer;
-	private Timer knockedOutTimer;
-	private VisibleOnScreenNotifier2D visibleOnScreen;
-
-	// Get the gravity from the project settings to be synced with RigidBody nodes.
-	public float gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
-
-	// Called when the node enters the scene tree for the first time.
+	private bool isActivated = false;
+	public float lastMovementX = Vector2.Left.X;
+	
 	public override void _Ready()
 	{
-		animationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
-		knockedOutTimer = GetNode<Timer>("KnockedOutTimer");
-		visibleOnScreen = GetNode<VisibleOnScreenNotifier2D>("VisibleOnScreen");
+		signalManager = GetNode<SignalManager>("/root/SignalManager");
+		stateMachine = GetNode<YorpStateMachine>("StateMachine");
 	}
 
 	public override void _PhysicsProcess(double delta)
 	{
-		if (!visibleOnScreen.IsOnScreen())
+		if (this.Velocity.Normalized().X != 0)
 		{
-			return;
+			lastMovementX = this.Velocity.Normalized().X;
 		}
-
-		Vector2 velocity = Velocity;
 		
-		// Add the gravity.
-		if (!IsOnFloor())
-		{
-			velocity.Y += gravity * (float)delta;
-			Velocity = velocity;
-		}
-		else
-		{
-			switch (state)
-			{
-				case YorpState.Idle:
-					//animationPlayer.Play("RESET");
-					Velocity = Velocity with { X = 0 };
-					break;
-
-				case YorpState.WalkingLeft:
-					//animationPlayer.Play("walk_left");
-					Velocity = Velocity with { X = -1 * Speed };
-					break;
-					
-				case YorpState.WalkingRight:
-					//animationPlayer.Play("walk_right");
-					Velocity = Velocity with { X = 1 * Speed };
-					break;
-
-				// case YorpState.Thinking:
-				// 	animationPlayer.Play("looking");
-				// 	break;
-
-				case YorpState.Jumping:
-					//Debug.Print("Yorp jumping");
-					Jump();
-					break;
-
-				// case YorpState.KnockedOut:
-				// 	animationPlayer.Play("dazed");
-				// 	break;
-
-				 case YorpState.Dying:
-				 	animationPlayer.Play("die");
-
-				 	break;
-			}
-		}
-
+		stateMachine.PhysicsProcess(delta, lastMovementX, isActivated);
 		MoveAndSlide();
 	}
 
 	private void KnockedOut(Node body)
 	{
-		Debug.Print("Yorp eye is sore");
-		if (body is Keen keen)
-		{
-			Debug.Print("Yorp knocked out");
-			//animationPlayer.Play("dazed");
-			UpdateState(YorpState.KnockedOut);
-			knockedOutTimer.Start();
-		}
-	}
-
-	private void KnockedOutTimeout()
-	{
-		//animationPlayer.Play("RESET");
-		UpdateState(YorpState.Idle);
-		Debug.Print("Yorp ok");
+		stateMachine.KnockedOut();
 	}
 
     public void TakeDamage()
     {
-		Health--;
-        //animationPlayer.Play("die");
-		knockedOutTimer.Stop();
-		UpdateState(YorpState.Dying);
+		stateMachine.TakeDamage();
     }
 
-	private void Jump()
+	public void OnScreenEntered()
 	{
-		if (IsOnFloor())
-		{
-			var random = new Random();
-			
-			Velocity = new Vector2(Velocity.X, random.Next((int)MaxJumpVelocity, 0));
-		}
+		isActivated = true;
 	}
 
 	public void ScreenExited()
 	{
+		isActivated = false;
 		if (!Camera.CameraRect.HasPoint(this.GlobalPosition))
 		{
 			Debug.Print($"Yorp is out of camera bounds: {this.GlobalPosition}");
 			QueueFree();
-		}
-	}
-
-	private void UpdateState(YorpState newState)
-	{
-		previousState = state;
-		state = newState;
-
-		if (previousState != state)
-		{
-			Debug.Print($"Yorp state changed from {previousState} to {state}");
-			switch (state)
-			{
-				case YorpState.Idle:
-					animationPlayer.Play("RESET");
-					break;
-
-				case YorpState.Thinking:
-					animationPlayer.Play("looking");
-					break;
-
-				case YorpState.KnockedOut:
-					animationPlayer.Play("dazed");
-					break;
-
-				case YorpState.Dying:
-					animationPlayer.Play("die");
-					break;
-			}
 		}
 	}
 }

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=3 uid="uid://cxi7xre6i724l"]
+[gd_scene load_steps=32 format=3 uid="uid://cxi7xre6i724l"]
 
 [ext_resource type="Texture2D" uid="uid://dagrrjfqo4cv0" path="res://sprites/yorp.png" id="1_bhl5i"]
 [ext_resource type="Script" uid="uid://4eewxqi34766" path="res://scenes/creatures/Yorp/Yorp.cs" id="1_wx8nb"]
@@ -180,6 +180,68 @@ tracks/3/keys = {
 }]
 }
 
+[sub_resource type="Animation" id="Animation_8cwy3"]
+resource_name = "look_left"
+length = 0.5
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [6, 5]
+}
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("StateMachine/Think")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"ThinkingFinished"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_p84it"]
+resource_name = "look_right"
+length = 0.5
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [6, 7]
+}
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("StateMachine/Think")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"ThinkingFinished"
+}]
+}
+
 [sub_resource type="Animation" id="Animation_4iu4c"]
 resource_name = "walk_left"
 length = 0.3
@@ -238,8 +300,8 @@ tracks/1/keys = {
 "values": [Vector2(5, -6.5)]
 }
 
-[sub_resource type="Animation" id="Animation_8cwy3"]
-resource_name = "look_left"
+[sub_resource type="Animation" id="Animation_p3bo8"]
+resource_name = "idle"
 length = 0.5
 tracks/0/type = "value"
 tracks/0/imported = false
@@ -248,54 +310,10 @@ tracks/0/path = NodePath("Sprite2D:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.25),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [6, 5]
-}
-tracks/1/type = "method"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("StateMachine/Think")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0.5),
+"times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"values": [{
-"args": [],
-"method": &"ThinkingFinished"
-}]
-}
-
-[sub_resource type="Animation" id="Animation_p84it"]
-resource_name = "look_right"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite2D:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.25),
-"transitions": PackedFloat32Array(1, 1),
 "update": 1,
-"values": [6, 7]
-}
-tracks/1/type = "method"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("StateMachine/Think")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0.5),
-"transitions": PackedFloat32Array(1),
-"values": [{
-"args": [],
-"method": &"ThinkingFinished"
-}]
+"values": [6]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_mlcmu"]
@@ -303,6 +321,7 @@ _data = {
 &"RESET": SubResource("Animation_vlyq1"),
 &"dazed": SubResource("Animation_2to7r"),
 &"die": SubResource("Animation_0tfb6"),
+&"idle": SubResource("Animation_p3bo8"),
 &"look_left": SubResource("Animation_8cwy3"),
 &"look_right": SubResource("Animation_p84it"),
 &"walk_left": SubResource("Animation_4iu4c"),
@@ -321,11 +340,16 @@ animation = &"look_left"
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_o224v"]
 animation = &"look_right"
 
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j8kw4"]
+animation = &"idle"
+
 [sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_j8kw4"]
 blend_point_0/node = SubResource("AnimationNodeAnimation_d82sg")
 blend_point_0/pos = -1.0
 blend_point_1/node = SubResource("AnimationNodeAnimation_o224v")
 blend_point_1/pos = 1.0
+blend_point_2/node = SubResource("AnimationNodeAnimation_j8kw4")
+blend_point_2/pos = 0.0
 blend_mode = 1
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_y647g"]
@@ -390,7 +414,7 @@ autoplay = "RESET"
 [node name="AnimationTree" type="AnimationTree" parent="."]
 tree_root = SubResource("AnimationNodeStateMachine_8rhep")
 anim_player = NodePath("../AnimationPlayer")
-parameters/Look/blend_position = -0.324291
+parameters/Look/blend_position = 0.288533
 parameters/Walk/blend_position = 0.0
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -418,9 +442,11 @@ animationTree = NodePath("../AnimationTree")
 script = ExtResource("3_8cwy3")
 
 [node name="JumpTimer" type="Timer" parent="StateMachine/Walk"]
+process_callback = 0
 one_shot = true
 
 [node name="WalkTimer" type="Timer" parent="StateMachine/Walk"]
+process_callback = 0
 one_shot = true
 
 [node name="Think" type="Node" parent="StateMachine"]
@@ -430,6 +456,7 @@ script = ExtResource("4_p3bo8")
 script = ExtResource("3_lkvrj")
 
 [node name="KnockedOutTimer" type="Timer" parent="StateMachine/Dazed"]
+process_callback = 0
 wait_time = 6.0
 one_shot = true
 

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -1,7 +1,12 @@
-[gd_scene load_steps=12 format=3 uid="uid://cxi7xre6i724l"]
+[gd_scene load_steps=30 format=3 uid="uid://cxi7xre6i724l"]
 
 [ext_resource type="Texture2D" uid="uid://dagrrjfqo4cv0" path="res://sprites/yorp.png" id="1_bhl5i"]
 [ext_resource type="Script" uid="uid://4eewxqi34766" path="res://scenes/creatures/Yorp/Yorp.cs" id="1_wx8nb"]
+[ext_resource type="Script" uid="uid://d2ykcrtkskta8" path="res://scenes/creatures/Yorp/WalkState.cs" id="3_8cwy3"]
+[ext_resource type="Script" uid="uid://dbufi5gll8xrb" path="res://scenes/creatures/Yorp/DazedState.cs" id="3_lkvrj"]
+[ext_resource type="Script" uid="uid://dtanxwhsbt2gg" path="res://scenes/creatures/Yorp/YorpStateMachine.cs" id="3_p3bo8"]
+[ext_resource type="Script" uid="uid://de135f4jgh44g" path="res://scenes/creatures/Yorp/ThinkingState.cs" id="4_p3bo8"]
+[ext_resource type="Script" uid="uid://k8j8d4bmqfpg" path="res://scenes/creatures/Yorp/DeathState.cs" id="4_yxusf"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_i62cy"]
 size = Vector2(8, 5)
@@ -175,22 +180,6 @@ tracks/3/keys = {
 }]
 }
 
-[sub_resource type="Animation" id="Animation_p84it"]
-resource_name = "looking"
-loop_mode = 1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite2D:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.25, 0.5, 0.75),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 1,
-"values": [6, 7, 6, 5]
-}
-
 [sub_resource type="Animation" id="Animation_4iu4c"]
 resource_name = "walk_left"
 length = 0.3
@@ -249,15 +238,126 @@ tracks/1/keys = {
 "values": [Vector2(5, -6.5)]
 }
 
+[sub_resource type="Animation" id="Animation_8cwy3"]
+resource_name = "look_left"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [6, 5]
+}
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("StateMachine/Think")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"ThinkingFinished"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_p84it"]
+resource_name = "look_right"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [6, 7]
+}
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("StateMachine/Think")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"ThinkingFinished"
+}]
+}
+
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_mlcmu"]
 _data = {
 &"RESET": SubResource("Animation_vlyq1"),
 &"dazed": SubResource("Animation_2to7r"),
 &"die": SubResource("Animation_0tfb6"),
-&"looking": SubResource("Animation_p84it"),
+&"look_left": SubResource("Animation_8cwy3"),
+&"look_right": SubResource("Animation_p84it"),
 &"walk_left": SubResource("Animation_4iu4c"),
 &"walk_right": SubResource("Animation_1mvt3")
 }
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_p3bo8"]
+animation = &"dazed"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_g274x"]
+animation = &"die"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_d82sg"]
+animation = &"look_left"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_o224v"]
+animation = &"look_right"
+
+[sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_j8kw4"]
+blend_point_0/node = SubResource("AnimationNodeAnimation_d82sg")
+blend_point_0/pos = -1.0
+blend_point_1/node = SubResource("AnimationNodeAnimation_o224v")
+blend_point_1/pos = 1.0
+blend_mode = 1
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_y647g"]
+animation = &"walk_left"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_686vx"]
+animation = &"walk_right"
+
+[sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_gmeuc"]
+blend_point_0/node = SubResource("AnimationNodeAnimation_y647g")
+blend_point_0/pos = -1.0
+blend_point_1/node = SubResource("AnimationNodeAnimation_686vx")
+blend_point_1/pos = 1.0
+blend_mode = 1
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_qpsbx"]
+advance_mode = 2
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_sc8hs"]
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_tli3e"]
+
+[sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_8rhep"]
+states/Dazed/node = SubResource("AnimationNodeAnimation_p3bo8")
+states/Dazed/position = Vector2(463, 256)
+states/Die/node = SubResource("AnimationNodeAnimation_g274x")
+states/Die/position = Vector2(739, 223)
+states/Look/node = SubResource("AnimationNodeBlendSpace1D_j8kw4")
+states/Look/position = Vector2(574, 89)
+states/Walk/node = SubResource("AnimationNodeBlendSpace1D_gmeuc")
+states/Walk/position = Vector2(357, 159)
+transitions = ["Start", "Walk", SubResource("AnimationNodeStateMachineTransition_qpsbx"), "Walk", "Look", SubResource("AnimationNodeStateMachineTransition_sc8hs"), "Dazed", "Look", SubResource("AnimationNodeStateMachineTransition_tli3e")]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_jgn1p"]
 radius = 7.0
@@ -265,7 +365,7 @@ height = 20.0
 
 [node name="Yorp" type="CharacterBody2D"]
 position = Vector2(0, -4)
-collision_layer = 64
+collision_layer = 16
 collision_mask = 99
 slide_on_ceiling = false
 safe_margin = 0.5
@@ -279,18 +379,19 @@ collision_mask = 2
 [node name="EyeCollision" type="CollisionShape2D" parent="Area2D"]
 position = Vector2(0, -6.5)
 shape = SubResource("RectangleShape2D_i62cy")
-disabled = true
 debug_color = Color(0.955172, 0.149873, 0.386387, 0.42)
-
-[node name="KnockedOutTimer" type="Timer" parent="."]
-wait_time = 6.0
-one_shot = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
-"": SubResource("AnimationLibrary_mlcmu")
+&"": SubResource("AnimationLibrary_mlcmu")
 }
 autoplay = "RESET"
+
+[node name="AnimationTree" type="AnimationTree" parent="."]
+tree_root = SubResource("AnimationNodeStateMachine_8rhep")
+anim_player = NodePath("../AnimationPlayer")
+parameters/Look/blend_position = -0.324291
+parameters/Walk/blend_position = 0.0
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_bhl5i")
@@ -308,6 +409,37 @@ scale = Vector2(2.6, 2.3)
 position = Vector2(0, 2)
 shape = SubResource("CapsuleShape2D_jgn1p")
 
+[node name="StateMachine" type="Node" parent="." node_paths=PackedStringArray("character", "animationTree")]
+script = ExtResource("3_p3bo8")
+character = NodePath("..")
+animationTree = NodePath("../AnimationTree")
+
+[node name="Walk" type="Node" parent="StateMachine"]
+script = ExtResource("3_8cwy3")
+
+[node name="JumpTimer" type="Timer" parent="StateMachine/Walk"]
+one_shot = true
+
+[node name="WalkTimer" type="Timer" parent="StateMachine/Walk"]
+one_shot = true
+
+[node name="Think" type="Node" parent="StateMachine"]
+script = ExtResource("4_p3bo8")
+
+[node name="Dazed" type="Node" parent="StateMachine"]
+script = ExtResource("3_lkvrj")
+
+[node name="KnockedOutTimer" type="Timer" parent="StateMachine/Dazed"]
+wait_time = 6.0
+one_shot = true
+
+[node name="Dead" type="Node" parent="StateMachine"]
+script = ExtResource("4_yxusf")
+
+[connection signal="screen_entered" from="VisibleOnScreenNotifier2D" to="." method="OnScreenEntered"]
+[connection signal="screen_exited" from="VisibleOnScreenNotifier2D" to="." method="ScreenExited"]
 [connection signal="body_entered" from="Area2D" to="." method="KnockedOut"]
-[connection signal="timeout" from="KnockedOutTimer" to="." method="KnockedOutTimeout"]
 [connection signal="screen_exited" from="VisibleOnScreen" to="." method="ScreenExited"]
+[connection signal="timeout" from="StateMachine/Walk/JumpTimer" to="StateMachine/Walk" method="Jump"]
+[connection signal="timeout" from="StateMachine/Walk/WalkTimer" to="StateMachine/Walk" method="OnTimerTimeout"]
+[connection signal="timeout" from="StateMachine/Dazed/KnockedOutTimer" to="StateMachine/Dazed" method="OnTimerTimeout"]

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -73,6 +73,18 @@ tracks/4/keys = {
 "update": 1,
 "values": [35]
 }
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath(".:collision_layer")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [16]
+}
 
 [sub_resource type="Animation" id="Animation_2to7r"]
 resource_name = "dazed"
@@ -160,24 +172,22 @@ tracks/2/path = NodePath(".:collision_mask")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0.0333333),
+"times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [1]
+"values": [33]
 }
-tracks/3/type = "method"
+tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath(".")
+tracks/3/path = NodePath(".:collision_layer")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
-"values": [{
-"args": [false],
-"method": &"set_physics_process"
-}]
+"update": 1,
+"values": [0]
 }
 
 [sub_resource type="Animation" id="Animation_p3bo8"]

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -409,6 +409,7 @@ script = ExtResource("1_wx8nb")
 [node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
 
 [node name="Area2D" type="Area2D" parent="."]
+collision_layer = 0
 collision_mask = 2
 
 [node name="EyeCollision" type="CollisionShape2D" parent="Area2D"]

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -71,7 +71,7 @@ tracks/4/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [99]
+"values": [35]
 }
 
 [sub_resource type="Animation" id="Animation_2to7r"]
@@ -178,6 +178,22 @@ tracks/3/keys = {
 "args": [false],
 "method": &"set_physics_process"
 }]
+}
+
+[sub_resource type="Animation" id="Animation_p3bo8"]
+resource_name = "idle"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [6]
 }
 
 [sub_resource type="Animation" id="Animation_8cwy3"]
@@ -300,22 +316,6 @@ tracks/1/keys = {
 "values": [Vector2(5, -6.5)]
 }
 
-[sub_resource type="Animation" id="Animation_p3bo8"]
-resource_name = "idle"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Sprite2D:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [6]
-}
-
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_mlcmu"]
 _data = {
 &"RESET": SubResource("Animation_vlyq1"),
@@ -390,7 +390,7 @@ height = 20.0
 [node name="Yorp" type="CharacterBody2D"]
 position = Vector2(0, -4)
 collision_layer = 16
-collision_mask = 99
+collision_mask = 35
 slide_on_ceiling = false
 safe_margin = 0.5
 script = ExtResource("1_wx8nb")
@@ -403,6 +403,7 @@ collision_mask = 2
 [node name="EyeCollision" type="CollisionShape2D" parent="Area2D"]
 position = Vector2(0, -6.5)
 shape = SubResource("RectangleShape2D_i62cy")
+disabled = true
 debug_color = Color(0.955172, 0.149873, 0.386387, 0.42)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -388,6 +388,7 @@ radius = 7.0
 height = 20.0
 
 [node name="Yorp" type="CharacterBody2D"]
+process_mode = 1
 position = Vector2(0, -4)
 collision_layer = 16
 collision_mask = 35
@@ -403,7 +404,6 @@ collision_mask = 2
 [node name="EyeCollision" type="CollisionShape2D" parent="Area2D"]
 position = Vector2(0, -6.5)
 shape = SubResource("RectangleShape2D_i62cy")
-disabled = true
 debug_color = Color(0.955172, 0.149873, 0.386387, 0.42)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -444,7 +444,6 @@ script = ExtResource("3_8cwy3")
 
 [node name="JumpTimer" type="Timer" parent="StateMachine/Walk"]
 process_callback = 0
-one_shot = true
 
 [node name="WalkTimer" type="Timer" parent="StateMachine/Walk"]
 process_callback = 0

--- a/scenes/creatures/Yorp/Yorp.tscn
+++ b/scenes/creatures/Yorp/Yorp.tscn
@@ -385,7 +385,7 @@ transitions = ["Start", "Walk", SubResource("AnimationNodeStateMachineTransition
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_jgn1p"]
 radius = 7.0
-height = 20.0
+height = 21.0
 
 [node name="Yorp" type="CharacterBody2D"]
 process_mode = 1
@@ -431,7 +431,7 @@ position = Vector2(-1.43051e-06, 1)
 scale = Vector2(2.6, 2.3)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(0, 2)
+position = Vector2(0, 1)
 shape = SubResource("CapsuleShape2D_jgn1p")
 
 [node name="StateMachine" type="Node" parent="." node_paths=PackedStringArray("character", "animationTree")]

--- a/scenes/creatures/Yorp/YorpBaseState.cs
+++ b/scenes/creatures/Yorp/YorpBaseState.cs
@@ -30,5 +30,10 @@ public abstract partial class YorpBaseState : Node, IState<YorpStateMachine.Yorp
     public void Exit()
     {
         NextState = null;
+        ExitState();
+    }
+
+    public virtual void ExitState()
+    {
     }
 }

--- a/scenes/creatures/Yorp/YorpBaseState.cs
+++ b/scenes/creatures/Yorp/YorpBaseState.cs
@@ -3,7 +3,7 @@ using Godot;
 namespace CommanderKeen.Scenes.Creatures.Yorp;
 public abstract partial class YorpBaseState : Node, IState<YorpStateMachine.YorpStates>
 {
-    internal const float Speed = 40.0f;
+    internal const float Speed = 25.0f;
     public CharacterBody2D Character { get; set; }
 
     public AnimationTree AnimationTree { get; set; }
@@ -15,7 +15,7 @@ public abstract partial class YorpBaseState : Node, IState<YorpStateMachine.Yorp
 
     internal AnimationNodeStateMachinePlayback playback { get => (AnimationNodeStateMachinePlayback)AnimationTree.Get("parameters/playback"); }
 
-    internal float gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
+    internal float gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle() / 1.5f;
 
     public virtual void StateInput(InputEvent inputEvent)
     {

--- a/scenes/creatures/Yorp/YorpBaseState.cs
+++ b/scenes/creatures/Yorp/YorpBaseState.cs
@@ -1,0 +1,34 @@
+using Godot;
+
+namespace CommanderKeen.Scenes.Creatures.Yorp;
+public abstract partial class YorpBaseState : Node, IState<YorpStateMachine.YorpStates>
+{
+    internal const float Speed = 40.0f;
+    public CharacterBody2D Character { get; set; }
+
+    public AnimationTree AnimationTree { get; set; }
+
+    public abstract YorpStateMachine.YorpStates StateType { get; }
+
+    public virtual bool CanMove => true;
+    public YorpStateMachine.YorpStates? NextState { get; set; }
+
+    internal AnimationNodeStateMachinePlayback playback { get => (AnimationNodeStateMachinePlayback)AnimationTree.Get("parameters/playback"); }
+
+    internal float gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
+
+    public virtual void StateInput(InputEvent inputEvent)
+    {
+    }
+
+    public abstract void PhysicsProcess(double delta, float lastMovementX);
+
+    public virtual void Enter()
+    {
+    }
+
+    public void Exit()
+    {
+        NextState = null;
+    }
+}

--- a/scenes/creatures/Yorp/YorpBaseState.cs.uid
+++ b/scenes/creatures/Yorp/YorpBaseState.cs.uid
@@ -1,0 +1,1 @@
+uid://cypfap3b585fi

--- a/scenes/creatures/Yorp/YorpStateMachine.cs
+++ b/scenes/creatures/Yorp/YorpStateMachine.cs
@@ -1,0 +1,82 @@
+using Godot;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+
+namespace CommanderKeen.Scenes.Creatures.Yorp;
+public partial class YorpStateMachine : Node
+{
+    public enum YorpStates
+	{
+		Walk,
+		Thinking,
+		Dazed,
+		Dead
+	}
+
+    private readonly Dictionary<YorpStates, IState<YorpStates>> states = [];
+
+    private IState<YorpStates> Current { get; set; }
+
+    [Export]
+	private Yorp character;
+
+	[Export]
+	private AnimationTree animationTree;
+
+    private CharacterBody2D player;
+
+    public override void _Ready()
+	{
+		foreach (YorpBaseState state in GetChildren().OfType<YorpBaseState>())
+		{
+			state.Character = character;
+			state.AnimationTree = animationTree;
+			states.Add(state.StateType, state);
+			Debug.Print("Yorp Added state: " + state.StateType);
+		}
+		
+		Current = states.First().Value;
+		Debug.Print("Yorp Default state: " + Current.StateType);
+		Current.Enter();
+	}
+
+    public void PhysicsProcess(double delta, float lastMovementX, bool isActivated)
+	{
+		if (!isActivated)
+		{
+			return;
+		}
+		
+		Current.PhysicsProcess(delta, lastMovementX);
+
+		if (Current.NextState.HasValue)
+		{
+			ChangeState(Current.NextState.Value);
+		}
+	}
+
+	private void ChangeState(YorpStates newState)
+	{
+		if (Current.StateType == newState)
+		{
+			return;
+		}
+		
+		Debug.Print($"Yorp State change - old: {Current.StateType}, New: {Current.NextState}");
+		Current.Exit();
+		Current = states[newState];
+		Current.Enter();
+	}
+
+	public void TakeDamage()
+	{
+		CallDeferred(nameof(ChangeState), (int)YorpStates.Dead);
+	}
+
+	public void KnockedOut()
+	{
+		CallDeferred(nameof(ChangeState), (int)YorpStates.Dazed);
+	}
+}

--- a/scenes/creatures/Yorp/YorpStateMachine.cs.uid
+++ b/scenes/creatures/Yorp/YorpStateMachine.cs.uid
@@ -1,0 +1,1 @@
+uid://dtanxwhsbt2gg

--- a/shared/SignalManager.cs
+++ b/shared/SignalManager.cs
@@ -47,4 +47,7 @@ public partial class SignalManager : Node
 
 	[Signal]
 	public delegate void PauseMenuEventHandler(bool paused, bool showSaveButton);
+
+	[Signal]
+	public delegate void KeenHitYorpEyeEventHandler();
 }


### PR DESCRIPTION
Make Yorps function like they do in the original game

Fixes #15 

Todo:
- [x] Bug - after being `dazed` does `thinking` state twice in quick succession
- [x] Bug - while `dazed` sometimes will jump
- [x] Fix jumping (is off compared to original)
- [x] Shove mechanism implemented
- [x] Bug - Dazed state fires off by walking into Keen
- [x] Bug - Yorp collides with other creatures
- [x] Keen pogo should disengage if he lands on the Yorp's eye
- [x] Bug - Yorp goes into dazed state when walking into Keen
- [ ] Bug - Yorp walks away after bumping into Keen