### PR TITLE
Allow action to pass for non format changes

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -3,24 +3,46 @@ name: .NET format
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - '**/*.cs'
-      - '**/*.csproj'
-      - '**/*.sln'
-      - '.github/workflows/format-code.yml'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - '**/*.cs'
-      - '**/*.csproj'
-      - '**/*.sln'
-      - '.github/workflows/format-code.yml'
 
 jobs:
-  dotnet-format:
-
+  # This job checks if C# files changed
+  check-changes:
     runs-on: ubuntu-latest
+    outputs:
+      has-cs-changes: ${{ steps.changes.outputs.has-cs-changes }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Check for C# changes
+      id: changes
+      run: |
+        if [ "${{ github.event_name }}" = "push" ]; then
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+        else
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+        fi
+        
+        echo "Changed files:"
+        echo "$CHANGED_FILES"
+        
+        if echo "$CHANGED_FILES" | grep -qE '\.(cs|csproj|sln)$|\.github/workflows/format-code\.yml$'; then
+          echo "has-cs-changes=true" >> $GITHUB_OUTPUT
+          echo "C# files or project files changed - will run formatting check"
+        else
+          echo "has-cs-changes=false" >> $GITHUB_OUTPUT
+          echo "No C# files or project files changed - skipping formatting check"
+        fi
 
+  # This job only runs if C# files changed
+  dotnet-format-check:
+    runs-on: ubuntu-latest
+    needs: check-changes
+    if: needs.check-changes.outputs.has-cs-changes == 'true'
+    
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
@@ -28,3 +50,23 @@ jobs:
       run: dotnet restore
     - name: Format
       run: dotnet format Commander-keen.sln --verify-no-changes --verbosity diagnostic
+
+  # This job always runs and succeeds, for ruleset compatibility
+  dotnet-format:
+    runs-on: ubuntu-latest
+    needs: [check-changes, dotnet-format-check]
+    if: always()
+    
+    steps:
+    - name: Report result
+      run: |
+        if [ "${{ needs.check-changes.outputs.has-cs-changes }}" = "true" ]; then
+          if [ "${{ needs.dotnet-format-check.result }}" = "success" ]; then
+            echo "✅ .NET formatting check passed"
+          else
+            echo "❌ .NET formatting check failed"
+            exit 1
+          fi
+        else
+          echo "⏭️ No C# files changed - formatting check skipped"
+        fi


### PR DESCRIPTION
Fixes #63 

The format check should occur if there is a change to any of the following:
- the action itself
- `.cs` file
- `.csproj` file
- `.sln` file

Otherwise it should pass as a skipped check.