### PR TITLE
Update build/release to no longer zip when not needed

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,8 +95,7 @@ jobs:
         fi
         echo "Linux build successful:"
         ls -la artifact/commander-keen-linux.x86_64
-        chmod +x artifact/commander-keen-linux.x86_64
-
+        
     - name: Build macOS platform
       run: |
         echo "Building macOS platform..."
@@ -120,6 +119,7 @@ jobs:
       run: |
         sudo chown -R $USER:$USER artifact/
         sudo chmod -R 755 artifact/
+        sudo chmod +x artifact/commander-keen-linux.x86_64
 
     - name: Upload Windows artifact
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
Updates to `actions/upload-artifact` from v7+ no longer require/force things into zip files.
Also removes some dead code that was removed when rethinking and refactoring the original build