### PR TITLE
Change raygun collisions shape

### DIFF
--- a/scenes/raygun/raygunShot.tscn
+++ b/scenes/raygun/raygunShot.tscn
@@ -5,9 +5,8 @@
 [ext_resource type="Texture2D" uid="uid://bjomncvydxqbc" path="res://sprites/zap.png" id="3_73o7a"]
 [ext_resource type="AudioStream" uid="uid://c3hy7x0tffyqb" path="res://sfx/28912__junggle__btn102.wav" id="3_ejal4"]
 
-[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_umtd2"]
-radius = 3.0
-height = 6.0
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_1pkog"]
+size = Vector2(6, 7)
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_1pkog"]
 light_mode = 1
@@ -23,10 +22,9 @@ amount = 64
 lifetime = 0.1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1273000873]
-position = Vector2(7, -1)
+position = Vector2(4.5, -1.0000001)
 rotation = 1.5707964
-shape = SubResource("CapsuleShape2D_umtd2")
-one_way_collision = true
+shape = SubResource("RectangleShape2D_1pkog")
 
 [node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="." unique_id=1897862482]
 position = Vector2(0.999999, -1)


### PR DESCRIPTION
Shot collisions are now rectangular instead of circular so they collide better, also changed from being one direction (as this wasn't really working as expected anyway)